### PR TITLE
Enable Travis-CI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = packages/tau
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    *tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ installed
 # Misc
 *~
 benchmarks
+
+# Python coverage data
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: python
+
+branches:
+  except:
+    - gh-pages
+
+git:
+  depth: 99999
+
+sudo: false
+os:
+  - linux
+
+cache:
+    directories:
+        - "$HOME/.cache/pip"
+        - "$HOME/.pyenv"
+
+env:
+  - PYENV_VERSION='2.7.9' OS='Ubuntu Precise' # Add more python versions to this array to expand test matrix
+
+matrix:
+  include:
+    - language: generic
+      os: osx
+      osx_image: xcode7.1 # Corresponds to 10.10.x (Yosemite)
+      env:
+        - PYENV_VERSION='2.7.9' OS='OS X Yosemite'
+    - language: generic
+      os: osx
+      osx_image: xcode7.2 # Corresponds to 10.11.x (El Capitan)
+      env:
+        - PYENV_VERSION='2.7.9' OS='OS X El Capitan'
+
+install:
+  - source .travis/install.sh
+  - python --version
+
+script: # Currently pylint is bombing with negative scores. This might be due to a bad python environment and/or updates needed in pylintrc
+  - coverage run runtests
+  - make -C docs
+#  - [[ -n ${TAU_PY_CHANGED_FILES} ]] && pylint --rcfile=pylintrc $TAU_PY_CHANGED_FILES # pylint changed files only... WIP
+#  - pylint --rcfile=pylintrc packages/tau # Ensure global pylint compliance eventually... WIP
+
+after_success:
+  - codecov --env PYENV_VERSION OS
+
+deploy:
+  provider: script
+  script: .travis/deploy-docs.sh
+  skip_cleanup: true
+  on:
+    branch: master
+    condition: $TRAVIS_OS_NAME = linux &&  $PYENV_VERSION = '2.7.9'
+    repo: ParaToolsInc/taucmdr # Don't try to deploy on private forks
+
+notifications:
+  webhooks:
+    urls: # gitter.im announcement
+      secure: TQIzGX9yWDc+ayKNpWmNjCCucaGCwt9CYeThbzdmGsA30hJkRRuDNdx5ZDvknRktV+h+QYgLGLR3ueVUuGL0/kf23vPUZD6kTTY0c3ZJ4fonDx5Ydr+zhc1iJzO/Ord1tnY5xxfvKpfWEUekFQT5SSJMt61CQoNmVSDdTDpFcMC4GEzeQD6fdP0BxgiFvw4UOnfU/poM9OmjaVdKoFyax1+gub4mC/GG9faxK6IdtOAtPsGcUOpzBypwj3NRGgDuq+jErnvm3tLitVJz8h1ab5eQMgTAlCK8q3w7x/WaWxsVXnErjDqJIGs9mpxmyOJERoRv7hQdlAZtKlIZsdGpE7O9B9ooBE/zAfRqGHee5CsA/UKx6XDt9h0rYt/zNJ5RcIrbHRZMilwdC4PXXjN7FNNkpDp0LhhpzM19tZx9+Zb/QAGOTwIDq5adQfiF9ctE7OAlvqnSbvhTL0bzLmYthIURc9nBks4uqUAKq/LEnHz2CgiL8fGaJbUXqGSBc/prKYREa9ckfBdjFfngSnLBJB6oLKQBGRA/Y8thi7etu8TZD9CsWcBJhXFJTPkFArFkJVRpURNpQ0OIS54q0bmTW+dPbSJ95v2GEttCuAIyqDgffuwqqVYx0KmaMHKvxUGx0Mu8uC9Mo5FLEDiM05mE/lAgkK9wgwbgFW+A5g2t7x8=
+    on_success: change  # options: [always|never|change]
+    on_failure: always
+    on_start: always
+  slack:
+    secure: t0NM8J4361OMrUZSrXA8ECvMm7qulTmAwJhCoZz8+UkdEkRB9ubEc9Ka+BYALpDlbjrUaHzvsJdBhnNJNazQQN659KadjLYqtUbEvlL0+TkYar7WzNJnlB71ysxE8WGph2+KEo7Ld97ruvYURxUzedn9E/ZXRhSmqwbq/gVKdy2+To0EwXJ3n70LvyUW8RtU/NSmWSmeRSiidxAslG14aOKBhHuyUeLA60C+L42qf1BUKZYZc7jv14Tq8fnKkPQa/UHqMyyp8cWpNAvAm+UUjUoyq4Yt487TGMaXKpg9Z0XNHY8B67OXp0v20Vl2RdzwKtT958SpRXPx8/FOa3lA0i1/3uixsm10MNOZxjjwBMcdmj4l+eqfEMBDW2V1oBIUOHn++tIy7Wh25qWtBJB6H9PGcACL75B8czuutdzi20tfBcgmoB+DEiiiXvsvMAdHl2DTIkU4ts9hQmq1ZoNizLX8NO7slCjtg/pztdR8ABe4Dq7/mgNkKpeAyH0gtstPePJdTq/A7EGUOtC3shacZCsct5sF5hZpFW4wpOraI5kC6zHhV/r2fpnQ/r1jOQfpT5hZeTS0JdLUGm58awQg3N0Z+prTGj6fJRz7bBpyII3klBshdlwXWpxkS3r13HWCiJrayVEf76uruGQg8ica9167lEDSfoISESO2TDyrXw0=
+    on_success: change  # options: [always|never|change]
+    on_failure: always
+    on_start: always

--- a/.travis/deploy-docs.sh
+++ b/.travis/deploy-docs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Script to deploy Sphinx documentation to gh-pages branch automatically with Travis-CI
+#
+#set -o pipefail
+#set -o errexit
+#set -o nounset
+set -o verbose
+
+git config user.name "Travis-CI-bot"
+git config user.email "info@paratools.com"
+
+git remote -v
+git remote rm origin
+git remote add origin https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git
+git remote -v | sed 's#\(https://\)\(.*\)\(@github\.com/[^ ]*\)#\1SECRET\3#g'
+
+git fetch origin gh-pages > /dev/null 2>&1 && echo success || echo failure
+git branch -a -vvv || echo "git branch fails if on detatched head"
+
+export PUSH_FLAGS='--quiet --force'
+export HIDE_TOKEN='> /dev/null 2>&1'
+export COMMIT_MSG="Updated documentation on Travis-CI job $TRAVIS_JOB_NUMBER at commit $TRAVIS_COMMIT"
+make -C docs update-github-pages

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#set -o pipefail
+#set -o errexit
+#set -o verbose
+
+# Install pyenv to globally manage python versions
+# See https://github.com/yyuu/pyenv for further details
+echo "$PYENV_ROOT"
+
+export PYENV_ROOT="$HOME/.pyenv"
+export PATH="$PYENV_ROOT/bin:$PATH"
+
+if [ ! -x "$PYENV_ROOT/bin/pyenv" ]; then
+    curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
+fi
+
+if [ ! -d "$PYENV_ROOT/.git" ]; then # pyenv install script failed, try manual install
+    git clone --no-checkout -v https://github.com/yyuu/pyenv.git "$HOME/tmp"
+    mv "$HOME/tmp/.git" "$PYENV_ROOT/"
+    rmdir "$HOME/tmp"
+    cd "$PYENV_ROOT"
+    git reset --hard HEAD
+    cd -
+fi
+
+ls -a ~/.pyenv
+ls ~/.pyenv/bin
+
+eval "$(pyenv init -)"
+eval "$(pyenv virtualenv-init -)"
+
+pyenv update ||true
+
+export PYENV_VERSION="${PYENV_VERSION:-2.7.9}"
+pyenv install -s ${PYENV_VERSION}
+pyenv global ${PYENV_VERSION}
+pyenv rehash
+pyenv versions
+pyenv which pip
+
+# Create a clean virtualenv to isolate the environment from Travis-CI defaults
+python -m pip install --user virtualenv
+python -m virtualenv "$HOME/.venv"
+source "$HOME/.venv/bin/activate"
+
+# Install development requirements enumerated in requirements.txt
+pip install -r requirements.txt
+
+export PATH="$PWD/bin:$PATH"
+
+
+### Determine the files changed in the commit range being tested
+export MY_OS=${TRAVIS_OS_NAME}
+export REPO_SLUG=${TRAVIS_REPO_SLUG:-ParaToolsInc/taucmdr}
+export GIT_COMMIT=${TRAVIS_COMMIT:-"$(git rev-parse HEAD)"}
+export COMMIT_RANGE=${TRAVIS_COMMIT_RANGE:-"$(git rev-parse HEAD)^..$(git rev-parse HEAD)"}
+export PR=${TRAVIS_PULL_REQUEST:-false}
+
+# Be carefull here; pull requests with forced pushes can potentially
+# cause issues
+_diff_range="$(sed 's/\.\.\./../' <<< $COMMIT_RANGE )"
+if [ "$PR" != "false" ]; then # Use github API to get changed files
+  [ "X$MY_OS" = "Xosx" ] && (brew update > /dev/null || true ; brew install jq || true)
+  _files_changed=($(curl "https://api.github.com/repos/$REPO_SLUG/pulls/$PR/files" 2> /dev/null | \
+			 jq '.[] | .filename' | tr '"' ' '))
+  if [[ ${#_files_changed[@]} -eq 0 || -z ${_files_changed[@]} ]]; then
+    echo "Using git to determine changed files"
+    # no files detected, try using git instead
+    # This approach may only pick up files from the most recent commit, but that's
+    # better than nothing
+    _files_changed=($(git diff --name-only "$_diff_range" | sort -u || \
+                      git diff --name-only "${GIT_COMMIT}^..${GIT_COMMIT}" | sort -u ))
+  else
+    echo "Using Github API to determine changed files"
+  fi
+else
+  echo "Using git to determine changed files"
+  # We should be ok using git, see https://github.com/travis-ci/travis-ci/issues/2668
+  _files_changed=($(git diff --name-only "$_diff_range" | sort -u || \
+                    git diff --name-only "${GIT_COMMIT}^..${GIT_COMMIT}" | sort -u ))
+fi
+
+FILES_CHANGED=()
+TAU_PY_CHANGED_FILES=()
+for file in "${_files_changed[@]}"; do
+  if [[ ! -f "$file" ]]; then
+      echo "File $file no longer exists, removing from list of changed files"
+  else
+      FILES_CHANGED+=("$file")
+      if [[ "$file" == *packages/tau* ]]; then
+	  if head -n 1 "$file" | grep '^#!/usr/bin/env python' > /dev/null ; then
+	      TAU_PY_CHANGED_FILES+=("$file")
+	  elif [[ "$file" == *.py ]]; then
+	      TAU_PY_CHANGED_FILES+=("$file")
+	  fi
+      fi
+  fi
+done
+
+echo "Files changed in $COMMIT_RANGE:"
+for f in "${FILES_CHANGED[@]}"; do
+    echo "    $f"
+done
+echo "TAU commander Python files changed:"
+for f in "${TAU_PY_CHANGED_FILES[@]}"; do
+    echo "    $f"
+done
+
+tmp=${FILES_CHANGED[@]}
+unset FILES_CHANGED
+export FILES_CHANGED=$(sort -u <<< ${tmp}) # Can't export array variables
+echo "Files changed: ${FILES_CHANGED:-<none>}"
+tmp=${TAU_PY_CHANGED_FILES[@]}
+unset TAU_PY_CHANGED_FILES
+export TAU_PY_CHANGED_FILES=$(sort -u <<< ${tmp})
+echo "TAU Commander changed python files: ${TAU_PY_CHANGED_FILES:-<none>}"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 TAU Commander
 =============
 
+[![Build Status][Build img]](https://travis-ci.org/ParaToolsInc/taucmdr)
+[![Coverage Status][Coverage img]](https://codecov.io/github/ParaToolsInc/taucmdr?branch=master)
+[![GitHub license][License img]](./LICENSE)
+
 ![The TAU Commander performance engineering solution consists of an 
 intuitive, client-side application and cloud-hosted data analysis, 
 storage, and visualization services.](docs/source/_static/taucmdr.png)
@@ -50,3 +54,6 @@ DoE SBIR grant DE-SC0009593.
 
 [![Join the chat at https://gitter.im/jlinford/taucmdr](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jlinford/taucmdr?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+[Build img]: https://travis-ci.org/ParaToolsInc/taucmdr.svg?branch=master "Travis-CI build status image"
+[Coverage img]: https://codecov.io/github/ParaToolsInc/taucmdr/coverage.svg?branch=master "Unit test code coverage image"
+[License img]: https://img.shields.io/badge/license-BSD--3-blue.svg "View BSD-3 License"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,8 +10,14 @@
 #
 HERE := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-LOCAL_BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
+# Travis-CI tests pushed commits in a detatched head state. As a result,
+# `git rev-parse --abbrev-ref HEAD` won't always be meaningful. If the
+# environment variable TRAVIS_COMMIT is defined, then use this. If not,
+# then use `git rev-parse` (and assume we're on master).
+TRAVIS_COMMIT ?= $(shell git rev-parse --abbrev-ref HEAD)
+LOCAL_BRANCH := $(TRAVIS_COMMIT)
 DOCS_BRANCH = gh-pages
+COMMIT_MSG ?= Update documentation on $(DOCS_BRANCH) via Makefile
 
 SPHINX_BUILDER = html
 PROJECT_PACKAGE = tau
@@ -42,12 +48,12 @@ $(PACKAGE_REST_FILE): $(SOURCE_FILES)
 update-github-pages: 
 	git checkout $(DOCS_BRANCH)
 	git checkout $(LOCAL_BRANCH) $(PROJECT_DIR) $(HERE)
-	git rm -f .gitignore
+	-git rm -f .gitignore
 	$(MAKE) all
 	git add $(HERE)
 	git add -u $(HERE)
-	git commit -m "Update documentation on $(DOCS_BRANCH) via Makefile"
-	git push
+	git commit -m "$(COMMIT_MSG)" # Override on Travis-CI w/ environment var.
+	git push $(PUSH_FLAGS) origin $(DOCS-BRANCH) $(HIDE_TOKEN)
 	git checkout $(LOCAL_BRANCH)
 
 clean:

--- a/docs/source/continuous_integration.rst
+++ b/docs/source/continuous_integration.rst
@@ -1,0 +1,10 @@
+Continuous Integration
+======================
+
+Continuous Integration (CI) tests are run on the `Travis-CI.org`_ continuous integration hosting service, which is free to open-source projects hosted on `Github.com`_.
+The main settings file, ``.travis.yml``, controls the setup of the test environment on Ubuntu Linux and OS X host virtual machines (or docker containers).
+
+More coming soon...
+
+.. _`Travis-CI.org`: http://travis-ci.org
+.. _`Github.com`: https://github.com

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,7 +38,7 @@ The TAU Commandments
 5. **Never** shalt thou develop on the master branch, for that is an abomination.
 6. **Never** shalt thou merge broken code to the master branch.
 7. **Never** shalt thou *just quickly fix this one thing because I have a hard deadline I forgot and now I really really really need this feature to be part of TAU Commander whatever the cost and oh God I broke it I broke it and everything is on fire*.
-
+8. **Never** shalt thou merge code into the master branch that is failing the continuous integration (CI) tests. At a *minimum*, one of the following must be fixed *on your topic branch* **prior** to merging with master: 1) The code that broke the build or failed the test(s) 2) the :doc:`continuous_integration` build 3) the `unit tests`_.
 
 Table of Contents
 =================
@@ -71,3 +71,4 @@ Modules
 .. _the TAU Commander website: http://www.taucommander.com/
 .. _TAU Performance System: http://tau.uoregon.edu/
 .. _pylint: http://www.pylint.org/
+.. _`unit tests`: ./unit_tests.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+codecov==1.6.3
+coverage==4.0.3
+pylint==1.5.4
+sphinx==1.3.6


### PR DESCRIPTION

closes #36

## Opening up a PR (pull request) for discussion and code review.

If @jlinford or others could please give a code review before merging this in, it would be much appreciated.

### Added functionality

- CI testing with [Travis-CI.org](http://travis-ci.org)
  - Asynchronous, free CI testing
  - Notifications when a build fails to the committers and authors in the commit range being tested
  - Tests PRs before merging them
     - Here is an example of what this will look like: https://github.com/zbeekman/taucmdr/pull/10
  - Notifications to gitter.im  and Slack rooms for taucmdr
- Tests run:
  - Unit tests via [`runtests`](https://github.com/ParaToolsInc/taucmdr/blob/master/runtests)
  - Distributable package build via [`build.sh`](https://github.com/ParaToolsInc/taucmdr/blob/master/build.sh)
  - Documentation extraction/compilation with Sphinx using [`docs/Makefile`](https://github.com/ParaToolsInc/taucmdr/blob/master/docs/Makefile)
  - :x: pylint not yet enabled due to configuration issues
- Code coverage
  - Info generated during CI tests using the python `coverage` module/tool
  - Coverage data uploaded to [Codecov.io](http://codecov.io)
  - Metrics can be set and programmatically enforced with settings there (and integration with github)
  - Pull request comments showing current coverage, changes in coverage from the diff and suggested lines to have the largest coverage impact (all configurable)
- Automatic deployment of the Sphinx documentation
  - See PR #38 for additional comments and info about this