### PR TITLE
`tau show` profiles in `MULTI__*` dirs \w `pprof`

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -1376,8 +1376,13 @@ class TauInstallation(Installation):
         retval = 0
         for path in paths:
             if not os.path.exists(path):
-                raise ConfigurationError("Profile file '%s' does not exist" % path)
-            retval += util.create_subprocess([os.path.join(self.bin_path, 'pprof'), '-a'], cwd=path, env=env)
+                raise ConfigurationError("Profile directory '%s' does not exist" % path)
+            for thisdir, dirs, files in os.walk(path):
+                if any(file_name.startswith("profile") for file_name in files):
+                    LOGGER.info("\nCurrent trial/metric directory: %s" % os.path.basename(thisdir))
+                    retval += util.create_subprocess([os.path.join(self.bin_path, 'pprof'), '-a'], cwd=thisdir, env=env)
+                else:
+                    raise ConfigurationError("No profile files found in '%s'" % path)
         return retval
     
     def _show_jumpshot(self, fmt, paths, env):


### PR DESCRIPTION
 - Fixes #213
 - Ensure profiles are actually there, throw a configurationError if there are
   none.
 - Emit name of trial dir or `MULTI__` dir so that we know which counter we're
   looking at

Not 100% sure this is the *best* way to accomplish this, but I couldn't find any evidence of the ability to simultaneously display multiple different metrics in pprof. Thoughts @jlinford (and anyone else?)