### PR TITLE
Fix Python version check

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -502,8 +502,9 @@ class TauInstallation(Installation):
                 uid_parts.append(self.dependencies[pkg].uid)
         # TAU changes if any of its hard-coded limits change
         uid_parts.extend([str(self._get_max_threads()), str(self._get_max_metrics())])
-        python_version = self.get_python_version(self.python_path)
-        uid_parts.extend([self.python_path, python_version])
+        if self.python_path:
+            python_version = self.get_python_version(self.python_path)
+            uid_parts.extend([self.python_path, python_version])
         return uid_parts
 
     def _get_max_threads(self):


### PR DESCRIPTION
To determine the TAU configuration UID, the Python version was used even if no Python was selected in the current configuration. This caused builds to break if no executable named `python` was present in the path, since no Python interpreter would be auto-detected.

This pull request changes it so that the Python version is checked only if the requested TAU configuration actually has a python_path set.