### PR TITLE
Fix install error with IBM CUDA Fortran compiler

### DIFF
--- a/packages/taucmdr/cli/commands/target/create.py
+++ b/packages/taucmdr/cli/commands/target/create.py
@@ -221,7 +221,7 @@ class TargetCreateCommand(CreateCommand):
                 pass
             else:
                 for role, comp in compilers.iteritems():
-                    if comp is None:
+                    if comp is None and role in family:
                         compilers[role] = family[role]
         sibling = next((comp for comp in compilers.itervalues() if comp is not None), None)
         for role, comp in compilers.iteritems():


### PR DESCRIPTION
When the using the IBM family compilers, a CUDA Fortran compiler is provided (xlcuf), but not a CUDA C++ compiler. This caused an error when trying to select the default compiler for the CUDA_CXX role.

This change checks whether the family actually supports a given role before trying to use it as the default.

Fixes #347.