### PR TITLE
Non-selected project exception handled

### DIFF
--- a/packages/taucmdr/model/experiment.py
+++ b/packages/taucmdr/model/experiment.py
@@ -120,10 +120,10 @@ class ExperimentController(Controller):
         """Ensures that we only operate on experiment records in the selected project."""
         try:
             return dict(keys, project=self._project_eid)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, ProjectSelectionError):
             try:
                 return [dict(key, project=self._project_eid) for key in keys]
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, ProjectSelectionError):
                 pass
         return keys
 


### PR DESCRIPTION
Crude fix for a user interface error, where when listing projects, experiments would try and access the selected project: when no project was selected, an unhandled exception was raised.