### PR TITLE
Exclude 'tag' argument in full TAU config

### DIFF
--- a/scripts/system_configure
+++ b/scripts/system_configure
@@ -197,7 +197,7 @@ def main(argv):
     parser.merge(initialize_cmd.parser, include_positional=False,
                  exclude_groups=['project arguments'],
                  exclude_arguments=['project-name', 'target-name', 'application-name', 'measurement-name',
-                                    'tau-options', 'from-tau-makefile', 'bare'])
+                                    'tau-options', 'from-tau-makefile', 'bare', 'tag'])
     args = parser.parse_args(argv)
 
     os.chdir(util.mkdtemp())


### PR DESCRIPTION
Adds the `tag` argument to the blacklist used in generating TAU configurations when performing a full install of TAU. Otherwise, it tries to use the default, which is an empty string, as an actual command-line argument to `tau init`.