### PR TITLE
Project listing support for all storage levels

### DIFF
--- a/packages/taucmdr/cli/cli_view.py
+++ b/packages/taucmdr/cli/cli_view.py
@@ -424,7 +424,7 @@ class ListCommand(AbstractCliView):
         keys = getattr(args, 'keys', None)
         style = getattr(args, 'style', None) or self.default_style
         storage_levels = arguments.parse_storage_flag(args)
-        return self._list_records(storage_levels, keys, style)
+        return self._list_records([l.name for l in storage_levels], keys, style)
 
     def _retrieve_records(self, ctrl, keys):
         """Retrieve modeled data from the controller.

--- a/packages/taucmdr/model/project.py
+++ b/packages/taucmdr/model/project.py
@@ -96,14 +96,17 @@ class ProjectController(Controller):
         return super(ProjectController, self).create(data)
 
     def delete(self, keys):
-        super(ProjectController, self).delete(keys)
+        to_delete = self.one(keys)
+
         try:
             selected = self.selected()
         except ProjectSelectionError:
             pass
         else:
-            if selected is None:
+            if selected == to_delete:
                 self.unselect()
+
+        super(ProjectController, self).delete(keys)
 
     def select(self, project, experiment=None):
         self.storage['selected_project'] = project.eid
@@ -115,7 +118,8 @@ class ProjectController(Controller):
             experiment.configure()
 
     def unselect(self):
-        del self.storage['selected_project']
+        if self.storage.contains({'key': 'selected_profile'}):
+            del self.storage['selected_project']
 
     def selected(self):
         try:


### PR DESCRIPTION
Fix level checking in project listing. This bug prevented the user from listing projects defined outside of the app directory.