### PR TITLE
Add mirrors

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -66,10 +66,10 @@ jobs:
           echo "BRANCH: ${GITHUB_REF#refs/*/}"
           BASEREF=${{ github.base_ref }}
           if [ "${BASEREF}" ]; then
-            echo "set-output name=baseref::${BASEREF#refs/*/}"
+            echo "::set-output name=baseref::${BASEREF#refs/*/}"
             echo "BASEREF: ${BASEREF#/refs/*/}"
           else
-            echo "set-output name=baseref::unstable"
+            echo "::set-output name=baseref::unstable"
             echo "BASEREF: unstable"
           fi
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,14 +61,33 @@ jobs:
           echo "::set-output name=home_dir::${HOME}"
           echo "::set-output name=taucmdr_system::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
           echo "::set-env name=__TAUCMDR_SYSTEM_PREFIX__::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
+          echo "::set-output name=branch::${GITHUB_REF#refs/*/}"
+          echo "::set-env name=BRANCH::${GITHUB_REF#refs/*/}"
+          echo "BRANCH: ${GITHUB_REF#refs/*/}"
+          BASEREF=${{ github.base_ref }}
+          if [ "${BASEREF}" ]; then
+            echo "set-output name=baseref::${BASEREF#refs/*/}"
+            echo "BASEREF: ${BASEREF#/refs/*/}"
+          else
+            echo "set-output name=baseref::unstable"
+            echo "BASEREF: unstable"
+          fi
 
       - name: Cache TAU sources
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.info.outputs.taucmdr_system}}/src
           key: ${{ matrix.os }}-system-src-${{ github.sha }}
           restore-keys: |
             ${{ matrix.os }}-system-src
+
+      - name: Cache pylint directory
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.info.outputs.home_dir }}/.pylint.d
+          key: ${{ matrix.os }}-pylint-cache-${{ steps.info.outputs.branch }}-${{ github.sha }}
+          restore-keys: |
+            ${{ matrix.os }}-pylint-cache-${{ steps.info.outputs.baseref }}
 
       - name: Install TAU Commander
         run: |

--- a/Makefile
+++ b/Makefile
@@ -216,7 +216,10 @@ clean:
 	$(ECHO)$(RM) -r $(BUILDDIR) VERSION
 
 dev-container:
-	$(ECHO)docker build --pull --rm -t $(DOCKER_IMG_NAME) .
+	$(ECHO)docker build --pull -t $(DOCKER_IMG_NAME) .
 
 run-container:
-	$(ECHO)docker run -i -t -v ${PWD}:/home/tau/src $(DOCKER_IMG_NAME):$(DOCKER_TAG)
+	$(ECHO)docker run -it --privileged -v ${PWD}:/home/tau/src $(DOCKER_IMG_NAME):$(DOCKER_TAG)
+
+test-container:
+	$(ECHO)docker run -it --privileged -v ${PWD}:/home/tau/src $(DOCKER_IMG_NAME):$(DOCKER_TAG)

--- a/packages/taucmdr/cf/software/binutils_installation.py
+++ b/packages/taucmdr/cf/software/binutils_installation.py
@@ -45,7 +45,8 @@ from taucmdr.cf.compiler.host import CC, CXX, PGI, GNU
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz'}
+REPOS = {None: ['http://ftp.gnu.org/gnu/binutils/binutils-2.27.tar.gz',
+                'http://fs.paratools.com/tau-mirror/binutils-2.27.tar.gz']}
 
 LIBRARIES = {None: ['libbfd.a']}
 

--- a/packages/taucmdr/cf/software/installation.py
+++ b/packages/taucmdr/cf/software/installation.py
@@ -214,9 +214,12 @@ class Installation(object):
         if src.lower() == 'download':
             self.src = self._lookup_target_os_list(repos)
             if isinstance(self.src, list):
-                self.srcs = self.src
+                self.srcs = self.src[:]
                 self.srcs_avail = self.srcs[:]
-                self.src = self.srcs.pop(0)
+                try:
+                    self.src = self.srcs.pop(0)
+                except IndexError:
+                    raise ConfigurationError("No sources provided for %s." % self.title)
             else:
                 self.srcs = []
                 self.srcs_avail = [self.src]

--- a/packages/taucmdr/cf/software/installation.py
+++ b/packages/taucmdr/cf/software/installation.py
@@ -339,13 +339,7 @@ class Installation(object):
                     return archive
         archive_prefix = os.path.join(highest_writable_storage().prefix, "src")
         archive = os.path.join(archive_prefix, os.path.basename(self.src))
-        #try:
         util.download(self.src, archive)
-        #except IOError:
-        #    hints = ("If a firewall is blocking access to this server, use another method to download "
-        #             "'%s' and copy that file to '%s' before trying this operation." % (self.src, archive_prefix),
-        #             "Check that the file or directory is accessible")
-        #    raise ConfigurationError("Cannot acquire source archive '%s'." % self.src, *hints)
         return archive
 
     def acquire_source(self, reuse_archive=True):

--- a/packages/taucmdr/cf/software/installation.py
+++ b/packages/taucmdr/cf/software/installation.py
@@ -336,13 +336,13 @@ class Installation(object):
                     return archive
         archive_prefix = os.path.join(highest_writable_storage().prefix, "src")
         archive = os.path.join(archive_prefix, os.path.basename(self.src))
-        try:
-            util.download(self.src, archive)
-        except IOError:
-            hints = ("If a firewall is blocking access to this server, use another method to download "
-                     "'%s' and copy that file to '%s' before trying this operation." % (self.src, archive_prefix),
-                     "Check that the file or directory is accessible")
-            raise ConfigurationError("Cannot acquire source archive '%s'." % self.src, *hints)
+        #try:
+        util.download(self.src, archive)
+        #except IOError:
+        #    hints = ("If a firewall is blocking access to this server, use another method to download "
+        #             "'%s' and copy that file to '%s' before trying this operation." % (self.src, archive_prefix),
+        #             "Check that the file or directory is accessible")
+        #    raise ConfigurationError("Cannot acquire source archive '%s'." % self.src, *hints)
         return archive
 
     def acquire_source(self, reuse_archive=True):
@@ -366,8 +366,8 @@ class Installation(object):
             return self.src
         # Check that archive is valid by getting archive top-level directory
         while self.src:
-            archive = self._acquire_source(reuse_archive)
             try:
+                archive = self._acquire_source(reuse_archive)
                 util.archive_toplevel(archive)
             except IOError:
                 if reuse_archive:
@@ -386,9 +386,11 @@ class Installation(object):
             else:
                 return archive
         if self.src is None:
-            raise ConfigurationError(
-                "Unable to acquire %s source package '%s'" % (self.name, ', '.join(self.srcs_avail))
-            )
+            archive_prefix = os.path.join(highest_writable_storage().prefix, "src")
+            hints = ("If a firewall is blocking access to this server, use another method to download "
+                     "'%s' and copy that file to '%s' before trying this operation." % (self.src, archive_prefix),
+                     "Check that the file or directory is accessible")
+            raise ConfigurationError("Cannot acquire source archive '%s'." % ', '.join(self.srcs_avail), *hints)
         else:
             return archive
 

--- a/packages/taucmdr/cf/software/libotf2_installation.py
+++ b/packages/taucmdr/cf/software/libotf2_installation.py
@@ -33,7 +33,10 @@ The OTF2 library  provides an interface to write and read trace data.
 from taucmdr.cf.software.installation import AutotoolsInstallation
 
 
-REPOS = {None: 'http://tau.uoregon.edu/otf2.tgz'}
+REPOS = {None: [
+    'http://tau.uoregon.edu/otf2.tgz',
+    'http://fs.paratools.com/tau-mirror/otf2.tgz'
+]}
 
 LIBRARIES = {None: ['libotf2.la', 'libotf2.a']}
 

--- a/packages/taucmdr/cf/software/libunwind_installation.py
+++ b/packages/taucmdr/cf/software/libunwind_installation.py
@@ -46,8 +46,11 @@ from taucmdr.cf.compiler.host import CC, CXX, PGI, GNU
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/libunwind-1.3.1.tar.gz',
-         ARM64: {LINUX: 'http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/libunwind-1.3-rc1.tar.gz'}}
+REPOS = {None: [
+    'http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/libunwind-1.3.1.tar.gz',
+    'http://fs.paratools.com/tau-mirror/libunwind-1.3.1.tar.gz'],
+         ARM64: {LINUX: ['http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/libunwind-1.3-rc1.tar.gz',
+                         'http://fs.paratools.com/tau-mirror/libunwind-1.3.-rc1.tar.gz']}}
 
 LIBRARIES = {None: ['libunwind.a']}
 

--- a/packages/taucmdr/cf/software/ompt_installation.py
+++ b/packages/taucmdr/cf/software/ompt_installation.py
@@ -38,7 +38,10 @@ from taucmdr.cf.compiler.host import CC, CXX
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://tau.uoregon.edu/LLVM-openmp-0.2.tar.gz'}
+REPOS = {None: [
+    'http://tau.uoregon.edu/LLVM-openmp-0.2.tar.gz',
+    'http://fs.paratools.com/tau-mirror/LLVM-openmp-0.2.tar.gz'
+]}
 
 LIBRARIES = {None: ['libomp.so']}
 
@@ -50,7 +53,10 @@ class OmptInstallation(CMakeInstallation):
 
     def __init__(self, sources, target_arch, target_os, compilers):
         if sources['ompt'] == 'download-tr6':
-            sources['ompt'] = 'http://tau.uoregon.edu/LLVM-openmp-ompt-tr6.tar.gz'
+            sources['ompt'] = [
+                'http://tau.uoregon.edu/LLVM-openmp-ompt-tr6.tar.gz',
+                'http://fs.paratools.com/tau-mirror/LLVM-openmp-ompt-tr6.tar.gz'
+            ]
         super(OmptInstallation, self).__init__('ompt', 'ompt', sources, target_arch, target_os,
                                                compilers, REPOS, None, LIBRARIES, HEADERS)
 

--- a/packages/taucmdr/cf/software/papi_installation.py
+++ b/packages/taucmdr/cf/software/papi_installation.py
@@ -45,7 +45,8 @@ from taucmdr.cf.compiler.host import CC, CXX, IBM, GNU
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz'}
+REPOS = {None: ['http://icl.utk.edu/projects/papi/downloads/papi-5.5.1.tar.gz',
+         'http://fs.paratools.com/tau-mirror/papi-5.5.1.tar.gz']}
 
 LIBRARIES = {None: ['libpapi.a']}
 

--- a/packages/taucmdr/cf/software/pdt_installation.py
+++ b/packages/taucmdr/cf/software/pdt_installation.py
@@ -42,26 +42,21 @@ from taucmdr.cf.compiler.host import CC, CXX, PGI, GNU, INTEL
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: [
+PDT_REPOS = [
     'http://tau.uoregon.edu/pdt.tgz',
     'http://fs.paratools.com/tau-mirror/pdt.tgz'
-    ],
-         X86_64: {None: [
-             'http://tau.uoregon.edu/pdt.tgz',
-             'http://fs.paratools.com/tau-mirror/pdt.tgz'
-         ],
-                  LINUX:  [
-                      'http://tau.uoregon.edu/pdt_lite.tgz',
-                      'http://fs.paratools.com/tau-mirror/pdt_lite.tgz'
-                    ]},
-         INTEL_KNL: {None: [
-             'http://tau.uoregon.edu/pdt.tgz',
-             'http://fs.paratools.com/tau-mirror/pdt.tgz'
-         ],
-                     LINUX:  [
-                         'http://tau.uoregon.edu/pdt_lite.tgz',
-                         'http://fs.paratools.com/tau-mirror/pdt_lite.tgz'
-                     ]}}
+]
+
+PDT_LITE_REPOS = [
+    'http://tau.uoregon.edu/pdt_lite.tgz',
+    'http://fs.paratools.com/tau-mirror/pdt_lite.tgz'
+]
+
+REPOS = {None: PDT_REPOS,
+         X86_64: {None: PDT_REPOS,
+                  LINUX: PDT_LITE_REPOS},
+         INTEL_KNL: {None: PDT_REPOS,
+                     LINUX: PDT_LITE_REPOS}}
 
 COMMANDS = {None:
             ['cparse',

--- a/packages/taucmdr/cf/software/pdt_installation.py
+++ b/packages/taucmdr/cf/software/pdt_installation.py
@@ -42,11 +42,26 @@ from taucmdr.cf.compiler.host import CC, CXX, PGI, GNU, INTEL
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://tau.uoregon.edu/pdt.tgz',
-         X86_64: {None: 'http://tau.uoregon.edu/pdt.tgz',
-                  LINUX:  'http://tau.uoregon.edu/pdt_lite.tgz'},
-         INTEL_KNL: {None: 'http://tau.uoregon.edu/pdt.tgz',
-                     LINUX:  'http://tau.uoregon.edu/pdt_lite.tgz'}}
+REPOS = {None: [
+    'http://tau.uoregon.edu/pdt.tgz',
+    'http://fs.paratools.com/tau-mirror/pdt.tgz'
+    ],
+         X86_64: {None: [
+             'http://tau.uoregon.edu/pdt.tgz',
+             'http://fs.paratools.com/tau-mirror/pdt.tgz'
+         ],
+                  LINUX:  [
+                      'http://tau.uoregon.edu/pdt_lite.tgz',
+                      'http://fs.paratools.com/tau-mirror/pdt_lite.tgz'
+                    ]},
+         INTEL_KNL: {None: [
+             'http://tau.uoregon.edu/pdt.tgz',
+             'http://fs.paratools.com/tau-mirror/pdt.tgz'
+         ],
+                     LINUX:  [
+                         'http://tau.uoregon.edu/pdt_lite.tgz',
+                         'http://fs.paratools.com/tau-mirror/pdt_lite.tgz'
+                     ]}}
 
 COMMANDS = {None:
             ['cparse',

--- a/packages/taucmdr/cf/software/scorep_installation.py
+++ b/packages/taucmdr/cf/software/scorep_installation.py
@@ -41,7 +41,8 @@ from taucmdr.cf.platforms import X86_64, IBM64, PPC64, PPC64LE
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://www.cs.uoregon.edu/research/tau/scorep.tgz'}
+REPOS = {None: ['http://www.cs.uoregon.edu/research/tau/scorep.tgz',
+                'http://fs.paratools.com/tau-mirror/scorep.tgz']}
 
 COMMANDS = {None:
             [

--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -66,7 +66,8 @@ from taucmdr.cf.platforms import INTEL_KNL, INTEL_KNC
 
 LOGGER = logger.get_logger(__name__)
 
-REPOS = {None: 'http://tau.uoregon.edu/tau.tgz'}
+REPOS = {None: ['http://tau.uoregon.edu/tau.tgz',
+                'http://fs.paratools.com/tau-mirror/tau.tgz']}
 
 NIGHTLY = 'http://fs.paratools.com/tau-nightly.tgz'
 


### PR DESCRIPTION
Resolves / Closes #321 

Add backup mirrors for when tau.uoregon.edu or, e.g., ftp.gnu.org is down.

Functionality tested by locally pointing the tau.tgz source url to a non-existent url, which resulted in a successful download and install from fs.paratools.com/tau-mirror/ . Then error handling was tested by breaking both the original URL and the mirror URL.

I think I should refactor the sources and mirrors for some of the software packages into constants, since they are used multiple times.