### PR TITLE
Support deprecation of attributes and attribute values

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -1015,6 +1015,8 @@ print(find_version())
                 # Keep reconfiguring the same source because that's how TAU works
                 if not (self.include_path and os.path.isdir(self.include_path)):
                     shutil.move(self._prepare_src(), self.install_prefix)
+                self.tau_version = self.get_tau_version(os.path.join(self.install_prefix, 'include/TAU.h.default'))
+                self.deprecation_check()
                 self._src_prefix = self.install_prefix
                 self.installation_sequence()
                 self.set_group()
@@ -1927,3 +1929,24 @@ print(find_version())
         p = re.compile(r'\d+\.\d+\.\d+')
         m = p.search(out)
         return m.group()
+
+    def get_tau_version(self, header_path):
+        with open(header_path) as f:
+            for line in f:
+                if line.startswith("#define TAU_VERSION"):
+                    verline = line
+                    break
+        verstr = re.findall('"([^"]*)"', verline)[0]
+        if verstr.endswith('-git'):
+            ver = verstr[:-len('-git')]
+        return ver
+
+    def deprecation_check(self):
+        print('deprecation check')
+        print(self.uses_ompt_tr4)
+        print(self.uses_ompt_tr6)
+        print(self.uses_ompt)
+        if self.uses_ompt_tr4:
+            LOGGER.warning("\"--ompt download-tr4\" is deprecated in TAU version %s and will be removed in a later release", self.tau_version)
+        if self.uses_ompt_tr6:
+            LOGGER.warning("\"--ompt download-tr6\" is deprecated in TAU version %s and will be removed in a later release", self.tau_version)

--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -1015,8 +1015,7 @@ print(find_version())
                 # Keep reconfiguring the same source because that's how TAU works
                 if not (self.include_path and os.path.isdir(self.include_path)):
                     shutil.move(self._prepare_src(), self.install_prefix)
-                self.tau_version = self.get_tau_version(os.path.join(self.install_prefix, 'include/TAU.h.default'))
-                self.deprecation_check()
+                self.tau_version = self.get_version(os.path.join(self.install_prefix, 'include/TAU.h.default'))
                 self._src_prefix = self.install_prefix
                 self.installation_sequence()
                 self.set_group()
@@ -1930,7 +1929,8 @@ print(find_version())
         m = p.search(out)
         return m.group()
 
-    def get_tau_version(self, header_path):
+    def get_version(self):
+        header_path = os.path.join(self.install_prefix, 'include/TAU.h.default')
         with open(header_path) as f:
             for line in f:
                 if line.startswith("#define TAU_VERSION"):
@@ -1940,13 +1940,3 @@ print(find_version())
         if verstr.endswith('-git'):
             ver = verstr[:-len('-git')]
         return ver
-
-    def deprecation_check(self):
-        print('deprecation check')
-        print(self.uses_ompt_tr4)
-        print(self.uses_ompt_tr6)
-        print(self.uses_ompt)
-        if self.uses_ompt_tr4:
-            LOGGER.warning("\"--ompt download-tr4\" is deprecated in TAU version %s and will be removed in a later release", self.tau_version)
-        if self.uses_ompt_tr6:
-            LOGGER.warning("\"--ompt download-tr6\" is deprecated in TAU version %s and will be removed in a later release", self.tau_version)

--- a/packages/taucmdr/model/experiment.py
+++ b/packages/taucmdr/model/experiment.py
@@ -250,13 +250,36 @@ class Experiment(Model):
                 if 'deprecated' in props:
                     if comp.controller(self.storage).search(self.eid)[0][attr] in props['deprecated']:
                         deprecated_option = comp.controller(self.storage).search(self.eid)[0][attr]
-                        depr_str = props['deprecated'][targ[attr]]
-                        depr  = [int(i) for i in depr_str.split('.')]
-                        depr.extend([0]*(3-len(depr)))
-                        if tau_version >= depr:
+                        dep = props['deprecated'][targ[attr]]
+                        if isinstance(dep, list):
+                            if len(dep) == 2 and dep[1] != '':
+                                rem_str = dep[1]
+                                rem = [int(i) for i in rem_str.split('.')]
+                                rem.extend([0]*(3-len(rem)))
+                                is_removed = tau_version >= rem
+                            else:
+                                is_removed = False
+
+                            if is_removed:
+                                is_deprecated = False
+                            else:
+                                depr_str = dep[0]
+                                depr  = [int(i) for i in depr_str.split('.')]
+                                depr.extend([0]*(3-len(depr)))
+                                is_deprecated = tau_version >= depr
+                        else:
+                            depr_str = dep
+                            depr  = [int(i) for i in depr_str.split('.')]
+                            depr.extend([0]*(3-len(depr)))
+                            is_deprecated = tau_version >= depr
+                            is_removed = False
+
+                        if is_deprecated:
                             LOGGER.warning(
-                                "The \"--%s %s\" has been deprecated in TAU version %s and will be removed in a future release." %(attr, deprecated_option, depr_str)
+                                "The \"--%s %s\" option has been deprecated in TAU version %s and will be removed in a future release." %(attr, deprecated_option, depr_str)
                             )
+                        elif is_removed:
+                            raise ConfigurationError('The \"--%s %s\" option was removed in TAU version %s.' % (attr, deprecated_option, rem_str))
 
     def on_create(self):
         self.verify()

--- a/packages/taucmdr/model/experiment.py
+++ b/packages/taucmdr/model/experiment.py
@@ -94,6 +94,10 @@ def attributes():
             'type': 'string',
             'description': 'TAU Makefile used during this experiment, if any.'
         },
+        'tau_version': {
+            'type': 'string',
+            'description': 'TAU version used during this experiment'
+        },
         'record_output': {
             'type': 'boolean',
             'default': False,
@@ -234,6 +238,26 @@ class Experiment(Model):
             for rhs in [targ, app, meas]:
                 lhs.check_compatibility(rhs)
 
+        # Check for deprecated attributes
+        if 'tau_version' in self.controller(self.storage).search(self.eid)[0]:
+            tau_version_str = self.controller(self.storage).search(self.eid)[0]['tau_version']
+            tau_version = [int(i) for i in tau_version_str.split('.')]
+            tau_version.extend([0]*(3-len(tau_version)))
+        else:
+            return
+        for comp in [targ, app, meas]:
+            for attr, props in comp.attributes.iteritems():
+                if 'deprecated' in props:
+                    if comp.controller(self.storage).search(self.eid)[0][attr] in props['deprecated']:
+                        deprecated_option = comp.controller(self.storage).search(self.eid)[0][attr]
+                        depr_str = props['deprecated'][targ[attr]]
+                        depr  = [int(i) for i in depr_str.split('.')]
+                        depr.extend([0]*(3-len(depr)))
+                        if tau_version >= depr:
+                            LOGGER.warning(
+                                "The \"--%s %s\" has been deprecated in TAU version %s and will be removed in a future release." %(attr, deprecated_option, depr_str)
+                            )
+
     def on_create(self):
         self.verify()
         try:
@@ -347,6 +371,8 @@ class Experiment(Model):
         tau.install()
         if not baseline:
             self.controller(self.storage).update({'tau_makefile': os.path.basename(tau.get_makefile())}, self.eid)
+        self.controller(self.storage).update({'tau_version': tau.get_version()}, self.eid)
+        self.verify()
         return tau
 
     def managed_build(self, compiler_cmd, compiler_args):

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -475,7 +475,7 @@ def attributes():
                          'group': 'software package',
                          'metavar': '(<path>|<url>|download|download-tr4|download-tr6|None)',
                          'action': ParsePackagePathAction},
-            'deprecated': {'download-tr4' : '2.29.1', 'download-tr6' : '2.29.1'},
+            'deprecated': {'download-tr4' : ['2.29.1',''], 'download-tr6' : ['2.29.1','']},
             'rebuild_required': True
         },
         'libotf2_source': {

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -475,6 +475,7 @@ def attributes():
                          'group': 'software package',
                          'metavar': '(<path>|<url>|download|download-tr4|download-tr6|None)',
                          'action': ParsePackagePathAction},
+            'deprecated': {'download-tr4' : '2.29.1', 'download-tr6' : '2.29.1'},
             'rebuild_required': True
         },
         'libotf2_source': {
@@ -700,6 +701,9 @@ class Target(Model):
 
     def tau_metrics(self):
         return self.get_installation('tau').tau_metrics()
+
+    def tau_version(self):
+        return self.get_installation('tau').tau_version()
 
     def cupti_metrics(self):
         if not self.get('cuda'):


### PR DESCRIPTION
Based on issue #381. We just need to add a deprecated option to the option that has been deprecated/removed. Either a string or a list can be passed in. Then once it has been removed add a second element to the string,  i.e.:

ompt_source: {
...
'deprecated': {'download-tr4': '2.29.1'},
'deprecated': {'download-tr4': ['2.29.1']},
'deprecated': {'download-tr4': ['2.29.1', '']},
'deprecated': {'download-tr4': ['2.29.1', \<removed tau version\>]},
...
 }
