### PR TITLE
Use -unwinder=backtrace on ppc64le

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -766,7 +766,8 @@ class TauInstallation(Installation):
                     '-tag=%s' % self.uid,
                     '-arch=%s' % self.tau_magic.name,
                     '-bfd=%s' % binutils.install_prefix if binutils else None,
-                    '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else self.unwinder if self.unwinder != 'libunwind' else None,
+                    '-unwinder=%s' % self.unwinder,
+                    '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else None,
                    ] if flag]
             if util.create_subprocess(cmd, cwd=self._src_prefix, stdout=False, show_progress=True):
                 raise SoftwarePackageError('TAU configure failed')
@@ -850,7 +851,8 @@ class TauInstallation(Installation):
                   '-fortran=%s' % fortran_magic if fortran_magic else None,
                   '-bfd=%s' % binutils.install_prefix if binutils else None,
                   '-papi=%s' % papi.install_prefix if papi else None,
-                  '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else '-unwind=%s' % self.unwinder if self.unwinder != 'None' else None,
+                  '-unwinder=%s' % self.unwinder,
+                  '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else None,
                   '-dwarf=%s' % libdwarf.install_prefix if libdwarf else None,
                   '-elf=%s' % libelf.install_prefix if libdwarf else None,
                   '-scorep=%s' % scorep.install_prefix if scorep else None,

--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -425,7 +425,7 @@ class TauInstallation(Installation):
         self.unwind_depth = unwind_depth
         self.uses_pdt = not minimal and (self.source_inst == 'automatic' or self.shmem_support)
         self.uses_binutils = not minimal and (self.target_os is not DARWIN) and 'binutils' in sources
-        self.uses_libunwind = not minimal and (self.target_os is not DARWIN) and 'libunwind' in sources
+        self.uses_libunwind = not minimal and (self.target_os is not DARWIN) and 'libunwind' in sources and self.unwinder == 'libunwind'
         self.uses_libdwarf = not minimal and (self.target_os is not DARWIN) and 'libdwarf' in sources
         self.uses_libelf = not minimal and (self.target_os is not DARWIN) and 'libelf' in sources
         self.uses_papi = not minimal and bool(len([met for met in self.metrics if 'PAPI' in met]))
@@ -850,7 +850,7 @@ class TauInstallation(Installation):
                   '-fortran=%s' % fortran_magic if fortran_magic else None,
                   '-bfd=%s' % binutils.install_prefix if binutils else None,
                   '-papi=%s' % papi.install_prefix if papi else None,
-                  '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else self.unwinder if self.unwinder != 'libunwind' else None,
+                  '-unwind=%s' % libunwind.install_prefix if self.unwinder == 'libunwind' and libunwind else '-unwind=%s' % self.unwinder if self.unwinder != 'None' else None,
                   '-dwarf=%s' % libdwarf.install_prefix if libdwarf else None,
                   '-elf=%s' % libelf.install_prefix if libdwarf else None,
                   '-scorep=%s' % scorep.install_prefix if scorep else None,

--- a/packages/taucmdr/model/experiment.py
+++ b/packages/taucmdr/model/experiment.py
@@ -343,6 +343,7 @@ class Experiment(Model):
             tags=measurement.get_or_default('tag'),
             forced_makefile=target.get('forced_makefile', None),
             mpit=measurement.get_or_default('mpit'),
+            unwinder=target.get_or_default('unwinder'),
             unwind_depth=measurement.get_or_default('unwind_depth'))
         tau.install()
         if not baseline:
@@ -503,6 +504,7 @@ class Experiment(Model):
             ptts_report_flags=measurement.get_or_default('ptts_report_flags'),
             forced_makefile=target.get('forced_makefile', None),
             mpit=measurement.get_or_default('mpit'),
+            unwinder=target.get_or_default('unwinder'),
             unwind_depth=measurement.get_or_default('unwind_depth'),
             dyninst=dyninst)
         tau.install()

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -180,9 +180,9 @@ def attributes():
     knc_intel_mpi_only = _require_compiler_family(INTEL_MPI,
                                                   "You must use Intel MPI compilers to target the Xeon Phi (KNC)",
                                                   "Try adding `--mpi-wrappers=Intel` to the command line")
-    pgi_or_gnu = _require_compiler_family([PGI, GNU],
-                                              "You must use PGI or GNU compilers to use the backtrace unwinder",
-                                              "Try adding `--compilers=PGI` or `--compilers=GNU` to the command line")
+    gnu_only = _require_compiler_family([PGI, GNU],
+                                              "You must use GNU compilers to use the backtrace unwinder",
+                                              "Try adding `--compilers=GNU` to the command line")
 
     return {
         'projects': {
@@ -421,9 +421,9 @@ def attributes():
                           'group': 'software package',
                           'metavar': '(libunwind|backtrace)'},
             'compat': {'libunwind': Target.exclude('host_arch', PPC64LE),
-                       'backtrace': (Target.require(CC.keyword, pgi_or_gnu),
-                                     Target.require(CXX.keyword, pgi_or_gnu),
-                                     Target.require(FC.keyword, pgi_or_gnu))},
+                       'backtrace': (Target.require(CC.keyword, gnu_only),
+                                     Target.require(CXX.keyword, gnu_only),
+                                     Target.require(FC.keyword, gnu_only))},
             'rebuild_required': True
         },
         'libunwind_source': {

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -45,7 +45,7 @@ from taucmdr.mvc.controller import Controller
 from taucmdr.model.compiler import Compiler
 from taucmdr.cf import software
 from taucmdr.cf.platforms import Architecture, OperatingSystem
-from taucmdr.cf.platforms import HOST_ARCH, INTEL_KNC, HOST_OS, DARWIN, CRAY_CNL
+from taucmdr.cf.platforms import HOST_ARCH, INTEL_KNC, HOST_OS, DARWIN, CRAY_CNL, PPC64LE
 from taucmdr.cf.compiler import Knowledgebase, InstalledCompilerSet
 from taucmdr.cf.storage.levels import PROJECT_STORAGE, SYSTEM_STORAGE
 
@@ -176,6 +176,9 @@ def attributes():
     knc_intel_mpi_only = _require_compiler_family(INTEL_MPI,
                                                   "You must use Intel MPI compilers to target the Xeon Phi (KNC)",
                                                   "Try adding `--mpi-wrappers=Intel` to the command line")
+    pgi_or_gnu = _require_compiler_family([PGI, GNU],
+                                              "You must use Intel compilers to target the Xeon Phi (KNC)",
+                                              "Try adding `--compilers=Intel` to the command line")
 
     return {
         'projects': {
@@ -404,6 +407,17 @@ def attributes():
                          'metavar': '(<path>|<url>|download|None)',
                          'action': ParsePackagePathAction},
             'compat': {(lambda x: x is not None): Target.discourage('host_os', DARWIN)},
+            'rebuild_required': True
+        },
+        'unwinder': {
+            'type': 'string',
+            'description': 'name of unwinder to be used',
+            'default': 'backtrace' if HOST_ARCH is PPC64LE else 'libunwind',
+            'argparse': {'flags': ('--unwinder',),
+                          'group': 'software package',
+                          'metavar': '(libunwind|backtrace)'},
+            'compat': {'libunwind': Target.exclude('host_arch', PPC64LE),
+                       'backtrace': Target.require(pgi_or_gnu)},
             'rebuild_required': True
         },
         'libunwind_source': {

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -419,7 +419,7 @@ def attributes():
             'default': 'backtrace' if HOST_ARCH is PPC64LE else 'libunwind',
             'argparse': {'flags': ('--unwinder',),
                           'group': 'software package',
-                          'metavar': '(libunwind|backtrace)'},
+                          'metavar': '(libunwind|backtrace|None)'},
             'compat': {'libunwind': Target.exclude('host_arch', PPC64LE),
                        'backtrace': (Target.require(CC.keyword, gnu_only),
                                      Target.require(CXX.keyword, gnu_only),


### PR DESCRIPTION
Adds `--unwinder` target argument. Current available options are `backtrace`, `libunwind`, and `None`.