### PR TITLE
Fix build markdown

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -550,7 +550,7 @@ class BuildMarkdown(Command):
                          cmd_obj.usage]
                 filename = os.path.join(self.dest, cmd_name.replace('.', '_')+'.md')
                 with open(filename, 'w') as fout:
-                    fout.write(unidecode('\n'.join(parts).decode('utf-8')))
+                    fout.write(unidecode('\n'.join(parts)))
                 print('wrote %s' % filename)
                 indentspace = ''
 


### PR DESCRIPTION
While investigating #396 I noticed that

```bash
python setup.py build_markdown
```

was failing with:

```
[TAU] XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
[TAU]
[TAU] CRITICAL
[TAU]
[TAU] An unexpected AttributeError exception was raised:
[TAU]
[TAU] 'str' object has no attribute 'decode'
[TAU]
[TAU] Traceback (most recent call last):
[TAU]   File "setup.py", line 634, in <module>
[TAU]     'build_markdown': BuildMarkdown}
[TAU]   File "/home/ibeekman/taucmdr/conda/lib/python3.7/site-packages/setuptools/__init__.py", line 163, in setup
[TAU]     return distutils.core.setup(**attrs)
[TAU]   File "/home/ibeekman/taucmdr/conda/lib/python3.7/distutils/core.py", line 148, in setup
[TAU]     dist.run_commands()
[TAU]   File "/home/ibeekman/taucmdr/conda/lib/python3.7/distutils/dist.py", line 966, in run_commands
[TAU]     self.run_command(cmd)
[TAU]   File "/home/ibeekman/taucmdr/conda/lib/python3.7/distutils/dist.py", line 985, in run_command
[TAU]     cmd_obj.run()
[TAU]   File "setup.py", line 553, in run
[TAU]     fout.write(unidecode('\n'.join(parts).decode('utf-8')))
[TAU] AttributeError: 'str' object has no attribute 'decode'
[TAU]
[TAU] This is a bug in TAU Commander.
[TAU] Please send '/home/ibeekman/.local/taucmdr/debug_log' to <support@paratools.com> for assistance.
[TAU]
[TAU] XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
```