### PR TITLE
Fix error when using forced Makefile in non-scorep configuration

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -447,7 +447,7 @@ class TauInstallation(Installation):
         for met in self.metrics:
             mets.extend(met.split(','))
         self.metrics = mets
-        uses = lambda pkg: sources[pkg] if forced_makefile else getattr(self, 'uses_'+pkg)
+        uses = lambda pkg: sources.get(pkg, False) if forced_makefile else getattr(self, 'uses_'+pkg)
         for pkg in 'binutils', 'libunwind', 'libelf', 'libdwarf', 'papi', 'pdt', 'ompt', 'libotf2', 'sqlite3':
             if uses(pkg):
                 self.add_dependency(pkg, sources)


### PR DESCRIPTION
Fix error when using forced Makefile in non-scorep configuration. The check for which packages are used by a Makefile did not correctly handle the case where the dependency was not specified in the sources dictionary. This could result in a KeyError. Instead, return False if the package is absent from the dictionary.