### PR TITLE
Fix libdwarf requirements

### DIFF
--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -426,8 +426,8 @@ class TauInstallation(Installation):
         self.uses_pdt = not minimal and (self.source_inst == 'automatic' or self.shmem_support)
         self.uses_binutils = not minimal and (self.target_os is not DARWIN) and 'binutils' in sources
         self.uses_libunwind = not minimal and (self.target_os is not DARWIN) and 'libunwind' in sources and self.unwinder == 'libunwind'
-        self.uses_libdwarf = not minimal and (self.target_os is not DARWIN) and 'libdwarf' in sources
         self.uses_libelf = not minimal and (self.target_os is not DARWIN) and 'libelf' in sources
+        self.uses_libdwarf = not minimal and (self.target_os is not DARWIN) and 'libdwarf' in sources and self.uses_libelf 
         self.uses_papi = not minimal and bool(len([met for met in self.metrics if 'PAPI' in met]))
         self.uses_scorep = not minimal and (self.profile == 'cubex')
         self.uses_ompt = not minimal and (self.measure_openmp == 'ompt')

--- a/packages/taucmdr/cli/commands/trial/tests/test_create.py
+++ b/packages/taucmdr/cli/commands/trial/tests/test_create.py
@@ -135,6 +135,16 @@ class CreateTest(tests.TestCase):
         self.assertInLastTrialData("compute")
         self.assertInLastTrialData("malloc")
 
+    def test_without_libelf(self):
+        self.reset_project_storage(['--libelf', 'none'])
+        self.assertManagedBuild(0, CC, [], 'hello.c')
+        stdout, stderr = self.assertCommandReturnValue(0, trial_create_cmd, ['./a.out'])
+        self.assertIn('BEGIN targ1-app1', stdout)
+        self.assertIn('END targ1-app1', stdout)
+        self.assertIn('Trial 0 produced', stdout)
+        self.assertIn('profile files', stdout)
+        self.assertFalse(stderr)
+
     def test_without_libdwarf(self):
         self.reset_project_storage(['--libdwarf', 'none'])
         self.assertManagedBuild(0, CC, [], 'hello.c')


### PR DESCRIPTION
This branch is a response to issue #410. When a user tries `tau init --libelf None`, `libelf` is removed from the dependency sources however `libdwarf` tries to reference `libelf` in the dependency sources when it isn't available. By ensuring that `libelf` is being used before `libdwarf` references it, the error won't occur. 

A test case for `--libelf None` is also created.