### PR TITLE
Fix errors in `make install TAU=full`

### DIFF
--- a/packages/taucmdr/cf/software/libelf_installation.py
+++ b/packages/taucmdr/cf/software/libelf_installation.py
@@ -61,4 +61,4 @@ class LibelfInstallation(AutotoolsInstallation):
     def configure(self, flags):
         flags.extend(['--disable-debuginfod'])
         # Libelf's configure script requires CC to be a GNU compiler, so we have to set the environment variable before running the configure script
-        return super().configure(flags, env={'CC':GNU.installation()[CC].unwrap().absolute_path})
+        return super().configure(flags, env={'CC':GNU.installation()[CC].unwrap().absolute_path, 'CFLAGS': '-Wno-error', 'CXXFLAGS': '-Wno-error'})

--- a/packages/taucmdr/model/target.py
+++ b/packages/taucmdr/model/target.py
@@ -127,11 +127,14 @@ def level_zero_source_default():
     try:
         ld_lib_paths = os.environ['LD_LIBRARY_PATH'].split(':')
     except KeyError:
-        return 'download'
+        return None
     for path in ld_lib_paths:
         if os.path.isfile(path+'/libze_loader.so'):
             return path
-    return 'download'
+    # l0 isn't something TAU Commander can download and install itself
+    # (it's part of the oneAPI Toolkit), so if we can't find it,
+    # build TAU without it instead of trying to download it.
+    return None
 
 def cuda_toolkit_default():
     for path in sorted(glob.glob('/usr/local/cuda*')):
@@ -531,7 +534,7 @@ def attributes():
             'default': level_zero_source_default(),
             'argparse': {'flags': ('--level_zero_source',),
                          'group': 'software package',
-                         'metavar': '(<path>|<url>|download|None)',
+                         'metavar': '(<path>|None)',
                          'action': ParsePackagePathAction},
             'rebuild_required': True
         },


### PR DESCRIPTION
Fix two problems that were causing failures during a full install of TAU.

- Don't try to download and install level zero (we can't); just don't use it if it's not already installed
- Build libelf with `-Wno-error` to work around an upstream bug