### PR TITLE
Upgrade OTF2 to 3.1.1 to fix Python 3.12+ support

### DIFF
--- a/packages/taucmdr/cf/software/libotf2_installation.py
+++ b/packages/taucmdr/cf/software/libotf2_installation.py
@@ -33,11 +33,11 @@ from taucmdr.cf.software.installation import AutotoolsInstallation
 
 
 REPOS = {None: [
-    'https://tau.uoregon.edu/otf2-3.0.3.tgz',
-    'https://fs.paratools.com/tau-mirror/otf2-3.0.3.tgz'
+    'https://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/otf2-3.1.1.tar.gz',
+    'https://https://fs.paratools.com/tau-mirror/otf2-3.1.1.tar.gz'
 ]}
 
-LIBRARIES = {None: ['libotf2.la', 'libotf2.a']}
+LIBRARIES = {None: ['libotf2.so']}
 
 HEADERS = {None: ['otf2/otf2.h']}
 

--- a/packages/taucmdr/cf/software/sqlite3_installation.py
+++ b/packages/taucmdr/cf/software/sqlite3_installation.py
@@ -33,7 +33,10 @@ to store profile data in such a database.
 from taucmdr.cf.software.installation import AutotoolsInstallation
 
 
-REPOS = {None: 'http://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/sos/sqlite-autoconf-3210000.tar.gz'}
+REPOS = {None: [
+    'https://www.cs.uoregon.edu/research/paracomp/tau/tauprofile/dist/sos/sqlite-autoconf-3210000.tar.gz',
+    'https://fs.paratools.com/tau-mirror/sqlite-autoconf-3210000.tar.gz'
+]}
 
 LIBRARIES = {None: ['libsqlite3.a', 'libsqlite3.la', 'libsqlite3.so']}
 


### PR DESCRIPTION
TAU Commander was using libotf2 3.0.3. Building that version of libotf2 tries to import the `imp` module, which was removed in Python 3.12. Fixes by upgrading to libotf2 3.1.1, the latest version.

Also adds mirror for sqlite3, as there was a test failure which appeared to result from a transient outage of cs.uoregon.edu.