### PR TITLE
Upgrade GitHub Actions to latest versions and migrate to official Pages deployment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,7 @@ jobs:
           path: pylint.md
 
       - name: Pylint PR Comment
-        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' }}
+        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pylint-comment

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,7 @@ jobs:
           path: pylint.md
 
       - name: Pylint PR Comment
-        if: ${{ !env.ACT }} && matrix.os == 'ubuntu-22.04'
+        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pylint-comment
@@ -166,7 +166,7 @@ jobs:
           recreate: true
 
       - name: Upload Coverage info
-        if: ${{ !env.ACT }} && always()
+        if: ${{ !env.ACT && always() }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
           env_vars: OS,PY_VER,__TAUCMDR_PROGRESS_BARS__,__TAUCMDR_DB_BACKEND__,__TAUCMDR_SYSTEM_PREFIX__,GITHUB_WORKFLOW,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_ACTOR
 
       - name: Upload Sphinx docs for GitHub Pages
-        if: ${{ !env.ACT }} && success() && github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' ) && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb'
+        if: ${{ !env.ACT && success() && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable') && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb' }}
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./build/sphinx/html

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       __TAUCMDR_DB_BACKEND__: ${{ matrix.backend }}
       PY_VER: ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 9999
 
@@ -65,25 +65,25 @@ jobs:
           type -a python
           while read -r line ; do "${line##* is }" --version; done <<< $(type -a python)
           export INSTALLDIR="${HOME}/${INSTALLDIR}"
-          echo "::set-output name=install_dir::${INSTALLDIR}"
+          echo "install_dir=${INSTALLDIR}" >> "${GITHUB_OUTPUT}"
           echo "INSTALLDIR=${INSTALLDIR}" >> "${GITHUB_ENV}"
-          echo "::set-output name=home_dir::${HOME}"
-          echo "::set-output name=taucmdr_system::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
+          echo "home_dir=${HOME}" >> "${GITHUB_OUTPUT}"
+          echo "taucmdr_system=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_OUTPUT}"
           echo "__TAUCMDR_SYSTEM_PREFIX__=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_ENV}"
-          echo "::set-output name=branch::${GITHUB_REF#refs/*/}"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "${GITHUB_OUTPUT}"
           echo "BRANCH=${GITHUB_REF#refs/*/}" >> "${GITHUB_ENV}"
           echo "BRANCH: ${GITHUB_REF#refs/*/}"
           BASEREF=${{ github.base_ref }}
           if [ "${BASEREF}" ]; then
-            echo "::set-output name=baseref::${BASEREF#refs/*/}"
+            echo "baseref=${BASEREF#refs/*/}" >> "${GITHUB_OUTPUT}"
             echo "BASEREF: ${BASEREF#/refs/*/}"
           else
-            echo "::set-output name=baseref::unstable"
+            echo "baseref=unstable" >> "${GITHUB_OUTPUT}"
             echo "BASEREF: unstable"
           fi
 
       - name: Cache TAU sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.info.outputs.taucmdr_system}}/src
           key: ${{ matrix.os }}-system-src-${{ github.sha }}
@@ -91,7 +91,7 @@ jobs:
             ${{ matrix.os }}-system-src
 
       - name: Cache pylint directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.info.outputs.home_dir }}/.pylint.d
           key: ${{ matrix.os }}-pylint-cache-${{ steps.info.outputs.branch }}-${{ github.sha }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload TAU Commander install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-tau-minimal-debug-log-${{ matrix.os }}-${{ matrix.backend }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -145,14 +145,14 @@ jobs:
 
       - name: Upload TAU Commander unit test log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-unit-test-debug-log-${{ matrix.os }}-${{ matrix.backend }} 
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
 
       - name: Upload Pylint report
         if: always() && matrix.os == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-pylint-logs-${{ matrix.os }}-${{ matrix.backend }} 
           path: pylint.md
@@ -167,26 +167,19 @@ jobs:
 
       - name: Upload Coverage info
         if: ${{ !env.ACT }} && always()
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests,CI
           name: codecov-${{ matrix.os }}
           fail_ci_if_error: true # optional (default = false)
-          path_to_write_report: codecov-upload.txt
           env_vars: OS,PY_VER,__TAUCMDR_PROGRESS_BARS__,__TAUCMDR_DB_BACKEND__,__TAUCMDR_SYSTEM_PREFIX__,GITHUB_WORKFLOW,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_ACTOR
 
-      - name: Deploy Sphinx docs
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Sphinx docs for GitHub Pages
         if: ${{ !env.ACT }} && success() && github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' ) && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb'
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          enable_jekyll: false
-          allow_empty_commit: true
-          publish_dir: ./build/sphinx/html
-          username: ${{ github.actor }}
-          commitMessage: "Documentation for commit ${{ github.sha }}"
-          keep_files: false
+          path: ./build/sphinx/html
 
       - name: tau_validate
         if: always()
@@ -200,7 +193,26 @@ jobs:
 
       - name: Upload unit tests TAU validate
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-validate-${{ matrix.os }}-${{ matrix.backend }}-${{ github.sha }}
           path: ${{ steps.info.outputs.home_dir }}/tau-tests-validate
+
+  deploy-docs:
+    name: Deploy Sphinx docs to GitHub Pages
+    needs: Install-taucmdr-minimal
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' )
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
       OS: ${{ matrix.os }}
       PY_VER: ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 9999
 
@@ -60,12 +60,12 @@ jobs:
           type -a python
           while read -r line ; do "${line##* is }" --version; done <<< $(type -a python)
           export INSTALLDIR="${HOME}/${INSTALLDIR}"
-          echo "::set-output name=install_dir::${INSTALLDIR}"
+          echo "install_dir=${INSTALLDIR}" >> "${GITHUB_OUTPUT}"
           echo "INSTALLDIR=${INSTALLDIR}" >> "${GITHUB_ENV}"
-          echo "::set-output name=home_dir::${HOME}"
-          echo "::set-output name=taucmdr_system::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
+          echo "home_dir=${HOME}" >> "${GITHUB_OUTPUT}"
+          echo "taucmdr_system=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_OUTPUT}"
           echo "__TAUCMDR_SYSTEM_PREFIX__=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_ENV}"
-          echo "::set-output name=branch::${GITHUB_REF#refs/*/}"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "${GITHUB_OUTPUT}"
           echo "BRANCH=${GITHUB_REF#refs/*/}" >> "${GITHUB_ENV}"
           echo "BRANCH: ${GITHUB_REF#refs/*/}"
 
@@ -87,14 +87,14 @@ jobs:
 
       - name: Upload TAU Commander install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-tau-minimal-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
 
       - name: Upload TAU Commander minimal install
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-installation-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/taucmdr-nightly.zip
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload TAU Commander full-TAU install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload TAU Commander unit test log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-unit-test-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload nightly TAU validate
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-validate-${{ matrix.os }}-${{ github.sha }}
           path: ${{ steps.info.outputs.home_dir }}/tau-tests-validate

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ TAU Commander
 
 [![GitHub license][License img]](./LICENSE)
 [![CI][CI img]](https://github.com/ParaToolsInc/taucmdr/actions)
-[![Build Status][Build img]](https://travis-ci.org/ParaToolsInc/taucmdr)
 [![Coverage Status][Coverage img]](https://codecov.io/github/ParaToolsInc/taucmdr?branch=master)
 
 ![The TAU Commander performance engineering solution consists of an
@@ -83,7 +82,6 @@ Leadership Computing Facility (OLCF) at Oak Ridge National Laboratory.
 
 ---------------------------------------------------------------------------
 
-[CI img]: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=GH-Actions&event=push "GH Actions CI image"
-[Build img]: https://travis-ci.org/ParaToolsInc/taucmdr.svg?branch=master "Travis-CI build status image"
+[CI img]: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=master&event=push "GH Actions CI image"
 [Coverage img]: https://codecov.io/github/ParaToolsInc/taucmdr/coverage.svg?branch=master "Unit test code coverage image"
 [License img]: https://img.shields.io/badge/license-BSD--3-blue.svg "View BSD-3 License"

--- a/docs/continuous_integration.rst
+++ b/docs/continuous_integration.rst
@@ -1,11 +1,25 @@
 Continuous Integration
 ======================
 
-Continuous Integration (CI) tests are run on the `Travis-CI.org`_ continuous integration hosting service, which is free
-to open-source projects hosted on `Github.com`_. The main settings file, ``.travis.yml``, controls the setup of the test
-environment on Ubuntu Linux and OS X host virtual machines (or docker containers).
+.. image:: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=master&event=push
+   :target: https://github.com/ParaToolsInc/taucmdr/actions
+   :alt: CI Status
 
-More coming soon...
+TAU Commander uses `GitHub Actions`_ for continuous integration. The workflow
+configurations are defined in ``.github/workflows/`` and run automatically on
+every push and pull request.
 
-.. _`Travis-CI.org`: http://travis-ci.org
-.. _`Github.com`: https://github.com
+CI Workflows
+------------
+
+**CI** (``CI.yml``):
+  Installs TAU Commander, runs the full test suite against multiple database
+  backends (TinyDB and SQLite), builds the Sphinx documentation, reports code
+  coverage to Codecov, and deploys documentation to GitHub Pages on pushes to
+  ``master`` or ``unstable``.
+
+**Nightly** (``nightly.yml``):
+  Runs a more comprehensive nightly build that includes a full TAU installation
+  and ``tau_validate`` testing in addition to the standard test suite.
+
+.. _`GitHub Actions`: https://github.com/ParaToolsInc/taucmdr/actions


### PR DESCRIPTION
- Upgrade actions/checkout v2 -> v6, actions/cache v4 -> v5, actions/upload-artifact v4 -> v7, codecov/codecov-action v2 -> v5
- Replace peaceiris/actions-gh-pages with official actions/deploy-pages
- Replace deprecated ::set-output syntax with $GITHUB_OUTPUT
- Remove non-functional path_to_write_report param from codecov step
- Fix misspelled peaceiris params (username -> user_name, commitMessage -> commit_message)