### PR TITLE
fix(tau): detect CUPTI prefix explicitly to fix makefile name mismatch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,7 @@ jobs:
           path: pylint.md
 
       - name: Pylint PR Comment
-        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' }}
+        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pylint-comment

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -158,7 +158,7 @@ jobs:
           path: pylint.md
 
       - name: Pylint PR Comment
-        if: ${{ !env.ACT }} && matrix.os == 'ubuntu-22.04'
+        if: ${{ !env.ACT && matrix.os == 'ubuntu-22.04' }}
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pylint-comment
@@ -166,7 +166,7 @@ jobs:
           recreate: true
 
       - name: Upload Coverage info
-        if: ${{ !env.ACT }} && always()
+        if: ${{ !env.ACT && always() }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -176,7 +176,7 @@ jobs:
           env_vars: OS,PY_VER,__TAUCMDR_PROGRESS_BARS__,__TAUCMDR_DB_BACKEND__,__TAUCMDR_SYSTEM_PREFIX__,GITHUB_WORKFLOW,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_ACTOR
 
       - name: Upload Sphinx docs for GitHub Pages
-        if: ${{ !env.ACT }} && success() && github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' ) && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb'
+        if: ${{ !env.ACT && success() && github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable') && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb' }}
         uses: actions/upload-pages-artifact@v4
         with:
           path: ./build/sphinx/html

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,7 @@ jobs:
       __TAUCMDR_DB_BACKEND__: ${{ matrix.backend }}
       PY_VER: ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 9999
 
@@ -65,25 +65,25 @@ jobs:
           type -a python
           while read -r line ; do "${line##* is }" --version; done <<< $(type -a python)
           export INSTALLDIR="${HOME}/${INSTALLDIR}"
-          echo "::set-output name=install_dir::${INSTALLDIR}"
+          echo "install_dir=${INSTALLDIR}" >> "${GITHUB_OUTPUT}"
           echo "INSTALLDIR=${INSTALLDIR}" >> "${GITHUB_ENV}"
-          echo "::set-output name=home_dir::${HOME}"
-          echo "::set-output name=taucmdr_system::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
+          echo "home_dir=${HOME}" >> "${GITHUB_OUTPUT}"
+          echo "taucmdr_system=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_OUTPUT}"
           echo "__TAUCMDR_SYSTEM_PREFIX__=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_ENV}"
-          echo "::set-output name=branch::${GITHUB_REF#refs/*/}"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "${GITHUB_OUTPUT}"
           echo "BRANCH=${GITHUB_REF#refs/*/}" >> "${GITHUB_ENV}"
           echo "BRANCH: ${GITHUB_REF#refs/*/}"
           BASEREF=${{ github.base_ref }}
           if [ "${BASEREF}" ]; then
-            echo "::set-output name=baseref::${BASEREF#refs/*/}"
+            echo "baseref=${BASEREF#refs/*/}" >> "${GITHUB_OUTPUT}"
             echo "BASEREF: ${BASEREF#/refs/*/}"
           else
-            echo "::set-output name=baseref::unstable"
+            echo "baseref=unstable" >> "${GITHUB_OUTPUT}"
             echo "BASEREF: unstable"
           fi
 
       - name: Cache TAU sources
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.info.outputs.taucmdr_system}}/src
           key: ${{ matrix.os }}-system-src-${{ github.sha }}
@@ -91,7 +91,7 @@ jobs:
             ${{ matrix.os }}-system-src
 
       - name: Cache pylint directory
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.info.outputs.home_dir }}/.pylint.d
           key: ${{ matrix.os }}-pylint-cache-${{ steps.info.outputs.branch }}-${{ github.sha }}
@@ -114,7 +114,7 @@ jobs:
 
       - name: Upload TAU Commander install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-tau-minimal-debug-log-${{ matrix.os }}-${{ matrix.backend }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -145,14 +145,14 @@ jobs:
 
       - name: Upload TAU Commander unit test log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-unit-test-debug-log-${{ matrix.os }}-${{ matrix.backend }} 
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
 
       - name: Upload Pylint report
         if: always() && matrix.os == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-pylint-logs-${{ matrix.os }}-${{ matrix.backend }} 
           path: pylint.md
@@ -167,26 +167,19 @@ jobs:
 
       - name: Upload Coverage info
         if: ${{ !env.ACT }} && always()
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unittests,CI
           name: codecov-${{ matrix.os }}
           fail_ci_if_error: true # optional (default = false)
-          path_to_write_report: codecov-upload.txt
           env_vars: OS,PY_VER,__TAUCMDR_PROGRESS_BARS__,__TAUCMDR_DB_BACKEND__,__TAUCMDR_SYSTEM_PREFIX__,GITHUB_WORKFLOW,GITHUB_RUN_ID,GITHUB_RUN_NUMBER,GITHUB_ACTOR
 
-      - name: Deploy Sphinx docs
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Sphinx docs for GitHub Pages
         if: ${{ !env.ACT }} && success() && github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' ) && matrix.os == 'ubuntu-22.04' && matrix.backend == 'tinydb'
+        uses: actions/upload-pages-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          enable_jekyll: false
-          allow_empty_commit: true
-          publish_dir: ./build/sphinx/html
-          username: ${{ github.actor }}
-          commitMessage: "Documentation for commit ${{ github.sha }}"
-          keep_files: false
+          path: ./build/sphinx/html
 
       - name: tau_validate
         if: always()
@@ -200,7 +193,26 @@ jobs:
 
       - name: Upload unit tests TAU validate
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-validate-${{ matrix.os }}-${{ matrix.backend }}-${{ github.sha }}
           path: ${{ steps.info.outputs.home_dir }}/tau-tests-validate
+
+  deploy-docs:
+    name: Deploy Sphinx docs to GitHub Pages
+    needs: Install-taucmdr-minimal
+    if: github.event_name == 'push' && ( github.ref == 'refs/heads/master' || github.ref == 'refs/heads/unstable' )
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
       OS: ${{ matrix.os }}
       PY_VER: ${{ matrix.python_version }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 9999
 
@@ -60,12 +60,12 @@ jobs:
           type -a python
           while read -r line ; do "${line##* is }" --version; done <<< $(type -a python)
           export INSTALLDIR="${HOME}/${INSTALLDIR}"
-          echo "::set-output name=install_dir::${INSTALLDIR}"
+          echo "install_dir=${INSTALLDIR}" >> "${GITHUB_OUTPUT}"
           echo "INSTALLDIR=${INSTALLDIR}" >> "${GITHUB_ENV}"
-          echo "::set-output name=home_dir::${HOME}"
-          echo "::set-output name=taucmdr_system::${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}"
+          echo "home_dir=${HOME}" >> "${GITHUB_OUTPUT}"
+          echo "taucmdr_system=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_OUTPUT}"
           echo "__TAUCMDR_SYSTEM_PREFIX__=${INSTALLDIR}/${__TAUCMDR_SYSTEM_PREFIX__}" >> "${GITHUB_ENV}"
-          echo "::set-output name=branch::${GITHUB_REF#refs/*/}"
+          echo "branch=${GITHUB_REF#refs/*/}" >> "${GITHUB_OUTPUT}"
           echo "BRANCH=${GITHUB_REF#refs/*/}" >> "${GITHUB_ENV}"
           echo "BRANCH: ${GITHUB_REF#refs/*/}"
 
@@ -87,14 +87,14 @@ jobs:
 
       - name: Upload TAU Commander install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-tau-minimal-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
 
       - name: Upload TAU Commander minimal install
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-installation-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/taucmdr-nightly.zip
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload TAU Commander full-TAU install log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -130,7 +130,7 @@ jobs:
 
       - name: Upload TAU Commander unit test log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-unit-test-debug-log-${{ matrix.os }}
           path: ${{ steps.info.outputs.home_dir }}/.local/taucmdr/debug_log
@@ -147,7 +147,7 @@ jobs:
 
       - name: Upload nightly TAU validate
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: taucmdr-full-tau-validate-${{ matrix.os }}-${{ github.sha }}
           path: ${{ steps.info.outputs.home_dir }}/tau-tests-validate

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ TAU Commander
 
 [![GitHub license][License img]](./LICENSE)
 [![CI][CI img]](https://github.com/ParaToolsInc/taucmdr/actions)
-[![Build Status][Build img]](https://travis-ci.org/ParaToolsInc/taucmdr)
 [![Coverage Status][Coverage img]](https://codecov.io/github/ParaToolsInc/taucmdr?branch=master)
 
 ![The TAU Commander performance engineering solution consists of an
@@ -83,7 +82,6 @@ Leadership Computing Facility (OLCF) at Oak Ridge National Laboratory.
 
 ---------------------------------------------------------------------------
 
-[CI img]: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=GH-Actions&event=push "GH Actions CI image"
-[Build img]: https://travis-ci.org/ParaToolsInc/taucmdr.svg?branch=master "Travis-CI build status image"
+[CI img]: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=master&event=push "GH Actions CI image"
 [Coverage img]: https://codecov.io/github/ParaToolsInc/taucmdr/coverage.svg?branch=master "Unit test code coverage image"
 [License img]: https://img.shields.io/badge/license-BSD--3-blue.svg "View BSD-3 License"

--- a/docs/continuous_integration.rst
+++ b/docs/continuous_integration.rst
@@ -1,11 +1,25 @@
 Continuous Integration
 ======================
 
-Continuous Integration (CI) tests are run on the `Travis-CI.org`_ continuous integration hosting service, which is free
-to open-source projects hosted on `Github.com`_. The main settings file, ``.travis.yml``, controls the setup of the test
-environment on Ubuntu Linux and OS X host virtual machines (or docker containers).
+.. image:: https://github.com/ParaToolsInc/taucmdr/workflows/CI/badge.svg?branch=master&event=push
+   :target: https://github.com/ParaToolsInc/taucmdr/actions
+   :alt: CI Status
 
-More coming soon...
+TAU Commander uses `GitHub Actions`_ for continuous integration. The workflow
+configurations are defined in ``.github/workflows/`` and run automatically on
+every push and pull request.
 
-.. _`Travis-CI.org`: http://travis-ci.org
-.. _`Github.com`: https://github.com
+CI Workflows
+------------
+
+**CI** (``CI.yml``):
+  Installs TAU Commander, runs the full test suite against multiple database
+  backends (TinyDB and SQLite), builds the Sphinx documentation, reports code
+  coverage to Codecov, and deploys documentation to GitHub Pages on pushes to
+  ``master`` or ``unstable``.
+
+**Nightly** (``nightly.yml``):
+  Runs a more comprehensive nightly build that includes a full TAU installation
+  and ``tau_validate`` testing in addition to the standard test suite.
+
+.. _`GitHub Actions`: https://github.com/ParaToolsInc/taucmdr/actions

--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -896,11 +896,7 @@ class TauInstallation(Installation):
             pythoninc = get_command_output(
                 [python_path, '-c', 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))'])
 
-        # Build tag string including tags that get_tags() expects but TAU's
-        # configure doesn't automatically embed in Makefile filenames
         tag = self.uid
-        if self.cupti_prefix:
-            tag += '-cupti'
         if (not self.pthreads_support and self.openmp_support
                 and self.measure_openmp == 'ompt'
                 and not self.uses_ompt_tr6 and not self.uses_ompt_tr4):

--- a/packages/taucmdr/cf/software/tau_installation.py
+++ b/packages/taucmdr/cf/software/tau_installation.py
@@ -446,6 +446,11 @@ class TauInstallation(Installation):
         self.uses_sqlite3 = not minimal and (self.profile == 'sqlite')
         self.uses_cuda = not minimal and (self.cuda_prefix and (self.cuda_support or self.opencl_support))
         self.uses_level_zero = not minimal and self.measure_level_zero and 'level_zero' in sources
+        self.cupti_prefix = self._find_cupti_prefix() if self.uses_cuda else None
+        if self.uses_cuda and not self.cupti_prefix:
+            LOGGER.warning("CUDA toolkit at '%s' does not contain CUPTI headers. "
+                           "GPU kernel profiling via CUPTI will not be available.",
+                           self.cuda_prefix)
         if 'TIME' not in self.metrics[0]:
             # TAU assumes the first metric is always some kind of wallclock timer
             # so move the first wallclock metric to the front of the list
@@ -507,6 +512,33 @@ class TauInstallation(Installation):
         if os.environ.get('PE_ENV', '').lower() == 'cray':
             raise ConfigurationError("TAU Commander cannot be used with Cray compilers. ",
                                      "Replace PrgEnv-cray with PrgEnv-intel, PrgEnv-gnu, PrgEnv-nvidia, or PrgEnv-pgi and try again.")
+
+    def _find_cupti_prefix(self):
+        """Find the CUPTI installation directory within the CUDA toolkit.
+
+        Checks the same paths that TAU's configure script checks when
+        auto-detecting CUPTI from a -cuda=<dir> argument.
+
+        Returns:
+            str: Path to the CUPTI base directory, or None if not found.
+        """
+        if not self.cuda_prefix:
+            return None
+        cuda = self.cuda_prefix
+        arch = platform.machine()
+        osname = platform.system().lower()
+        candidates = [
+            os.path.join(cuda, 'extras', 'CUPTI'),
+            os.path.join(cuda, 'targets', '%s-%s' % (arch, osname)),
+            cuda,
+            os.path.join(cuda, 'extras', 'CUPTI.orig'),
+        ]
+        for base in candidates:
+            header = os.path.join(base, 'include', 'cupti_events.h')
+            if os.path.isfile(header):
+                LOGGER.debug("Found CUPTI headers at %s", header)
+                return base
+        return None
 
     def uid_items(self):
         uid_parts = [self.target_arch.name, self.target_os.name]
@@ -864,8 +896,18 @@ class TauInstallation(Installation):
             pythoninc = get_command_output(
                 [python_path, '-c', 'import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))'])
 
+        # Build tag string including tags that get_tags() expects but TAU's
+        # configure doesn't automatically embed in Makefile filenames
+        tag = self.uid
+        if self.cupti_prefix:
+            tag += '-cupti'
+        if (not self.pthreads_support and self.openmp_support
+                and self.measure_openmp == 'ompt'
+                and not self.uses_ompt_tr6 and not self.uses_ompt_tr4):
+            tag += '-v5'
+
         flags = [flag for flag in
-                 ['-tag=%s' % self.uid,
+                 ['-tag=%s' % tag,
                   '-arch=%s' % self.tau_magic.name,
                   '-cc=%s' % cc_command,
                   '-c++=%s' % cxx_command,
@@ -884,6 +926,7 @@ class TauInstallation(Installation):
                   '-mpilib=%s' % mpilib if mpilib else None,
                   '-mpilibrary=%s' % mpilibrary if mpilibrary else None,
                   '-cuda=%s' % self.cuda_prefix if self.uses_cuda else None,
+                  '-cupti=%s' % self.cupti_prefix if self.cupti_prefix else None,
                   '-opencl=%s' % self.opencl_prefix if self.opencl_prefix else None,
                   '-shmem' if self.shmem_support else None,
                   '-shmeminc=%s' % shmeminc if shmeminc else None,
@@ -1112,7 +1155,7 @@ class TauInstallation(Installation):
             tags.add('mpi')
         if self.openacc_support:
             tags.add('acc')
-        if self.cuda_support or self.opencl_support:
+        if self.cupti_prefix:
             tags.add('cupti')
         if self.shmem_support:
             tags.add('shmem')
@@ -1404,7 +1447,7 @@ class TauInstallation(Installation):
             opts.append('-v')
         if self.sample:
             opts.append('-ebs')
-        if self.measure_cuda:
+        if self.measure_cuda and self.cupti_prefix:
             opts.append('-cupti')
         if self.openacc_support:
             opts.append('-openacc')

--- a/packages/taucmdr/cf/software/tests/test_tau_installation.py
+++ b/packages/taucmdr/cf/software/tests/test_tau_installation.py
@@ -29,9 +29,71 @@
 Functions used for unit tests of tau_installation.py.
 """
 
+import os
+import tempfile
+from taucmdr import tests
+from taucmdr.cf.software.tau_installation import TauInstallation
 
-from taucmdr.tests import TestCase, not_implemented
 
-@not_implemented
-class TauInstallationTest(TestCase):
-    pass
+class TauInstallationTest(tests.TestCase):
+    """Tests for TauInstallation CUPTI detection and tagging."""
+
+    def setUp(self):
+        super().setUp()
+        # Give each test its own isolated temp directory so tests don't
+        # pollute each other's filesystem state.
+        self._cuda_tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._cuda_tmpdir, ignore_errors=True)
+        super().tearDown()
+
+    # ------------------------------------------------------------------ #
+    # Helpers                                                              #
+    # ------------------------------------------------------------------ #
+
+    def _make_cupti_header(self, *path_parts):
+        """Create a fake cupti_events.h under the per-test cuda tmpdir."""
+        inc = os.path.join(self._cuda_tmpdir, *path_parts, 'include')
+        os.makedirs(inc, exist_ok=True)
+        open(os.path.join(inc, 'cupti_events.h'), 'w').close()
+
+    def _fake_self(self, cuda_prefix):
+        class _FakeSelf:
+            pass
+        fs = _FakeSelf()
+        fs.cuda_prefix = cuda_prefix
+        return fs
+
+    # ------------------------------------------------------------------ #
+    # _find_cupti_prefix                                                   #
+    # ------------------------------------------------------------------ #
+
+    def test_find_cupti_standard_sdk_layout(self):
+        """extras/CUPTI/include/cupti_events.h — first candidate."""
+        self._make_cupti_header('extras', 'CUPTI')
+        result = TauInstallation._find_cupti_prefix(self._fake_self(self._cuda_tmpdir))
+        self.assertEqual(result, os.path.join(self._cuda_tmpdir, 'extras', 'CUPTI'))
+
+    def test_find_cupti_system_packaged_layout(self):
+        """<cuda>/include/cupti_events.h — third candidate (e.g. /usr)."""
+        self._make_cupti_header()
+        result = TauInstallation._find_cupti_prefix(self._fake_self(self._cuda_tmpdir))
+        self.assertEqual(result, self._cuda_tmpdir)
+
+    def test_find_cupti_orig_layout(self):
+        """extras/CUPTI.orig/include/cupti_events.h — fourth candidate."""
+        self._make_cupti_header('extras', 'CUPTI.orig')
+        result = TauInstallation._find_cupti_prefix(self._fake_self(self._cuda_tmpdir))
+        self.assertEqual(result, os.path.join(self._cuda_tmpdir, 'extras', 'CUPTI.orig'))
+
+    def test_find_cupti_returns_none_when_missing(self):
+        """No headers present: returns None."""
+        result = TauInstallation._find_cupti_prefix(self._fake_self(self._cuda_tmpdir))
+        self.assertIsNone(result)
+
+    def test_find_cupti_returns_none_when_no_cuda_prefix(self):
+        """No cuda_prefix: returns None without touching filesystem."""
+        result = TauInstallation._find_cupti_prefix(self._fake_self(None))
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

- Adds `_find_cupti_prefix()` to probe the same CUPTI candidate paths TAU's configure checks, covering standard SDK, system-packaged, CUDA 10.2+ target, and CUPTI.orig layouts
- Passes `-cupti=<path>` explicitly to TAU's configure when CUPTI is found, making Makefile filename generation deterministic
- Conditions the `cupti` tag in `get_tags()`, the `-tag=` string in `_install()`, and the runtime `-cupti` option on `cupti_prefix` rather than unconditionally on `cuda_support`
- Emits a warning when CUDA is present but CUPTI headers are not found

Fixes #432

- [x] ~⚠️ __*Merge after #434*__ ! ⚠️~

## Suggested local tests

- Run new unit tests: `python setup.py test --test-suite=taucmdr.cf.software.tests.test_tau_installation`
- Verify standard CUDA SDK layout (`/usr/local/cuda-*`): CUPTI found at `extras/CUPTI/`, tag included
- Verify system-packaged CUDA (`/usr`): CUPTI not found in `extras/CUPTI/`, warning logged, tag omitted, TAU configures and installs without CUPTI mismatch
- Verify CUDA without CUPTI does not produce "TAU Makefile not found" error